### PR TITLE
[bugfix] Block focus mode from triggering without data

### DIFF
--- a/src/entryPoints/background.ts
+++ b/src/entryPoints/background.ts
@@ -99,7 +99,17 @@ class BackgroundProcess {
 					if (request.toggle === true) {
 						// sync models if toggling on
 						this.classifierModels.syncModels()
+
+						// if the models are invalid, don't allow focus mode to be turned on
+						// this is already checked in the view layer, but we also want to make sure
+						// the background process doesn't allow it
+						if (this.classifierModels.modelsInvalid) {
+							SettingsRepository.setFocusModeSetting(false)
+							sendResponse({ toggleStatus: false, success: false })
+							return
+						}
 					}
+
 					SettingsRepository.setFocusModeSetting(request.toggle).then(value => {
 						sendResponse({ toggleStatus: value, success: true })
 					})

--- a/src/view/popup/PopUpView.tsx
+++ b/src/view/popup/PopUpView.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Spacer, Switch } from "@chakra-ui/react"
+import { Box, Flex, Spacer, Switch, Tooltip } from "@chakra-ui/react"
 import React, { useEffect, useState } from "react"
 import { Category, SiteSeen } from "../../data/models/Category"
 import { SiteData } from "../../data/models/SiteData"
@@ -157,6 +157,14 @@ export default function PopUpView({
 		updateSiteCategoryState(siteDataState!!) // this feels bad
 	}
 
+	const isDataInsufficient = (): boolean => {
+		// if there is not enough data to train the model
+		if (modelMetrics?.procrastination === 0 || modelMetrics?.productive === 0) {
+			return true
+		}
+		return false
+	}
+
 	return (
 		<Box maxW="400px" minW="300px" backgroundColor={COLORS.lightGrey} padding={4}>
 			{modelMetrics ? (
@@ -184,12 +192,20 @@ export default function PopUpView({
 					)}
 					<Spacer p={3} />
 					<Flex alignItems="center" justifyContent="center">
-						<Switch
-							isChecked={focusModeState === true}
-							isDisabled={focusModeState === "loading"}
-							onChange={toggleFocusMode}
-							m={2}
-						/>
+						<Tooltip 
+							hasArrow 
+							label="You need to have at least 1 site in each category"
+							isDisabled={!isDataInsufficient()}
+						>
+							<Switch
+								isChecked={focusModeState === true}
+								isDisabled={
+									(focusModeState === "loading" || isDataInsufficient())
+								}
+								onChange={toggleFocusMode}
+								m={2}
+							/>
+						</Tooltip>
 						Focus mode
 					</Flex>
 					<Spacer p={3} />


### PR DESCRIPTION
Added checks in both the background script, and the view layer in the popup to prevent the user from toggling focus mode on if there is insufficient data to train the model